### PR TITLE
Fix Bitwise OR row formatting in bitwise operators table

### DIFF
--- a/docs/cheatsheet/basics.md
+++ b/docs/cheatsheet/basics.md
@@ -365,7 +365,7 @@ Bitwise operators operate on 32-bit binary representations of numbers:
 | Operator | Description                  | Example   | Result |
 | -------- | ---------------------------- | --------- | ------ |
 | `&`      | Bitwise AND                  | `5 & 1`   | `1`    |
-| `|"      | Bitwise OR                   | `5 | 1`   | `5`    |
+| `\|`     | Bitwise OR                   | `5 \| 1`  | `5`    |
 | `^`      | Bitwise XOR                  | `5 ^ 1`   | `4`    |
 | `~`      | Bitwise NOT                  | `~5`      | `-6`   |
 | `<<`     | Left shift                   | `5 << 1`  | `10`   |


### PR DESCRIPTION
This PR fixes the Bitwise OR row in the bitwise operators table by:

- replacing the accidental `"` with the missing closing backtick,
- escaping the `|` character in the operator,
- escaping the `|` character in the example to prevent incorrect table parsing.